### PR TITLE
chore: drop support for node 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "yarn": "1.22.17"
   },
   "engines": {
-    "node": ">= v14.18.1"
+    "node": "^ v14.0.0 || >= 16.0.0"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
BREAKING CHANGE: node 15 is not supported.

Node 14 and 16 are though.